### PR TITLE
Fix non-relative paths in `dist/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/Kjens93/react-native-font-faces.git",
   "description": "Easily emulate @font-face behavior in react-native",
   "files": [
+    "src",
     "dist"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "repository": "https://github.com/Kjens93/react-native-font-faces.git",
   "description": "Easily emulate @font-face behavior in react-native",
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {
     "test": "jest",
     "build": "bob build",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "redent": "^3.0.0",

--- a/src/utilities/enableFontFaces.tsx
+++ b/src/utilities/enableFontFaces.tsx
@@ -4,7 +4,7 @@ import { overrideTextRenderFn } from './overrideTextRenderFn';
 import { registerGlobalFontFaces } from './registerGlobalFontFaces';
 import { overrideTextInputRenderFn } from './overrideTextInputRenderFn';
 import { getDynamicFontList } from './getDynamicFontList';
-import { EnableFontFacesResult } from 'src/types/EnableFontFacesResult';
+import { EnableFontFacesResult } from '../types/EnableFontFacesResult';
 
 export function enableFontFaces(fontFaces: FontFace[]): EnableFontFacesResult {
   overrideTextRenderFn();

--- a/src/utilities/enableFontFaces.web.tsx
+++ b/src/utilities/enableFontFaces.web.tsx
@@ -1,5 +1,5 @@
 import { FontFace } from '../types/FontFace';
-import { EnableFontFacesResult } from 'src/types/EnableFontFacesResult';
+import { EnableFontFacesResult } from '../types/EnableFontFacesResult';
 import { generateInlineStyleSheet } from './generateInlineStyleSheet';
 
 export function enableFontFaces(fontFaces: FontFace[]): EnableFontFacesResult {

--- a/src/utilities/getDynamicFontList.ts
+++ b/src/utilities/getDynamicFontList.ts
@@ -1,5 +1,5 @@
 import { FontFace } from '../types/FontFace';
-import { DynamicFontList } from 'src/types/DynamicFontList';
+import { DynamicFontList } from '../types/DynamicFontList';
 import { getDynamicFontListEntry } from './getDynamicFontListEntry';
 
 export function getDynamicFontList(fontFaces: FontFace[]): DynamicFontList {

--- a/src/utilities/getDynamicFontListEntry.ts
+++ b/src/utilities/getDynamicFontListEntry.ts
@@ -1,7 +1,7 @@
 import { FontFace } from '../types/FontFace';
 import { explodeToArray } from './explodeToArray';
 import { getLocalFontName } from './getLocalFontName';
-import { DynamicFontListEntry } from 'src/types/DynamicFontListEntry';
+import { DynamicFontListEntry } from '../types/DynamicFontListEntry';
 
 export function getDynamicFontListEntry(fontFace: FontFace): DynamicFontListEntry | undefined {
   for (const source of explodeToArray(fontFace.src)) {

--- a/src/utilities/getExpoFontMap.ts
+++ b/src/utilities/getExpoFontMap.ts
@@ -1,5 +1,5 @@
 import { FontFace } from '../types/FontFace';
-import { ExpoFontMap } from 'src/types/ExpoFontMap';
+import { ExpoFontMap } from '../types/ExpoFontMap';
 import { getLocalFontName } from './getLocalFontName';
 import { getExpoFontMapEntry } from './getExpoFontMapEntry';
 

--- a/src/utilities/registerGlobalFontFaces.tsx
+++ b/src/utilities/registerGlobalFontFaces.tsx
@@ -1,4 +1,4 @@
-import { FontFace } from 'src/types/FontFace';
+import { FontFace } from '../types/FontFace';
 import { globalFontFaces } from './globalFontFaces';
 import { getLocalFontName } from './getLocalFontName';
 


### PR DESCRIPTION
Fixes #126 

Also adds a `prepack` script so that installing from `git` will automatically compile the typescript code so it can be used directly. See: https://yarnpkg.com/advanced/rulebook/#packages-should-use-the-prepack-script-to-generate-dist-files-before-publishing