### PR TITLE
fix: RN 0.65 compatibility

### DIFF
--- a/src/utilities/overrideTextInputRenderFn.ts
+++ b/src/utilities/overrideTextInputRenderFn.ts
@@ -12,12 +12,15 @@ export function overrideTextInputRenderFn() {
     }
 
     overrideRenderFn(...args: any[]) {
-      const element = originalRenderFn.call(this, ...args);
-      const fontFaces = Object.values(globalFontFaces);
-      const originalStyle: TextStyle = StyleSheet.flatten([element.props.style]);
-      const overrideStyle: TextStyle = generateOverrideStyle(fontFaces, originalStyle);
-      const flattenedStyle: TextStyle = StyleSheet.flatten([originalStyle, overrideStyle]);
-      return React.cloneElement(element, { style: flattenedStyle });
+      if (args.length && args[0].style) {
+        const fontFaces = Object.values(globalFontFaces);
+        const originalStyle: TextStyle = StyleSheet.flatten([args[0].style]);
+        const overrideStyle: TextStyle = generateOverrideStyle(fontFaces, originalStyle);
+        const flattenedStyle: TextStyle = StyleSheet.flatten([originalStyle, overrideStyle]);
+        args.splice(0, 1, { ...args[0], style: flattenedStyle });
+      }
+
+      return originalRenderFn.call(this, ...args);
     }
   }
 

--- a/src/utilities/overrideTextRenderFn.ts
+++ b/src/utilities/overrideTextRenderFn.ts
@@ -12,12 +12,15 @@ export function overrideTextRenderFn() {
     }
 
     overrideRenderFn(...args: any[]) {
-      const element = originalRenderFn.call(this, ...args);
-      const fontFaces = Object.values(globalFontFaces);
-      const originalStyle: TextStyle = StyleSheet.flatten([element.props.style]);
-      const overrideStyle: TextStyle = generateOverrideStyle(fontFaces, originalStyle);
-      const flattenedStyle: TextStyle = StyleSheet.flatten([originalStyle, overrideStyle]);
-      return React.cloneElement(element, { style: flattenedStyle });
+      if (args.length && args[0].style) {
+        const fontFaces = Object.values(globalFontFaces);
+        const originalStyle: TextStyle = StyleSheet.flatten([args[0].style]);
+        const overrideStyle: TextStyle = generateOverrideStyle(fontFaces, originalStyle);
+        const flattenedStyle: TextStyle = StyleSheet.flatten([originalStyle, overrideStyle]);
+        args.splice(0, 1, { ...args[0], style: flattenedStyle });
+      }
+
+      return originalRenderFn.call(this, ...args);
     }
   }
 


### PR DESCRIPTION
React Native v0.65 refactored the `Text` component internals [here](https://github.com/facebook/react-native/commit/06ce64356594a921cd9ae4f71c15dd56dd0e53a3), which broke the implementation of `overrideRenderFn`. Custom font styles were not rendering like they had been prior to v0.65. Those using Expo and `expo-font` would see an error like `fontFamily "[font]" is not a system font and has not been loaded through Font.loadAsync.` This is because in recent versions of React Native, the `style` prop is not rendered on the `Text` element itself, but on the `NativeText` child element.

This PR changes `overrideTextRenderFn` to override styles pre-render instead of post-render. This fixes the issue and reduces the function's dependency on the internal implementation of the `Text` component. This also changes `overrideTextInputRenderFn` for consistency.

I believe this is compatible with all supported versions of React Native, but I only tested it with v0.64.2 and v0.68.2 on iOS.

I do not believe this is a breaking change because, to my knowledge, nothing inside the `Text` and `TextInput` components themselves relied on the font style given to them.